### PR TITLE
[WIP]READMEにDB設計を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 |Column|Type|Options|
 |------|----|-------|
-|group_name|string|null: false|
+|name|string|null: false|
 
 ### Association
 - has_many : user_groups
@@ -43,8 +43,8 @@
 
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|foreign_key: true|
-|group_id|integer|foreign_key: true|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
 
 ### Association
 - belongs_to : group
@@ -54,10 +54,10 @@
 
 |Column|Type|Options|
 |------|----|-------|
-|body|text|null: false|
+|body|text|
 |image|string|
-|group_id|integer|foreign_key: true|
-|user_id|integer|foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+|user_id|integer|null: false, foreign_key: true|
 
 ### Association
 - belongs_to : group

--- a/README.md
+++ b/README.md
@@ -1,10 +1,24 @@
 # README
 
+## Chatspace 要件定義（未完成）
+|ChatSpace機能|機能詳細|エンティティ|リレーション|
+|-------------|--------|------------|------------|
+|アカウント新規登録機能|Name,email,passwordを入力して新規アカウント作成|users||
+|アカウント編集機能|Nameとemailの変更可能|users||
+|ユーザーログイン機能|email,passwordで登録されているアカウントにログイン|users||
+|ユーザーログアウト機能|ログインしているアカウントからログアウト|users||
+|新規チャットグループ作成機能|グループ名とメンバーを追加して新規チャットグループ作成|groups||
+|チャットグループ編集機能|表示中のチャットグループのグループ名変更、メンバーの追加削除|groups||
+|チャットグループ切替機能|表示するチャットグループの切替|groups||
+|テキスト投稿機能|テキストメッセージを投稿|messages||
+|画像投稿機能|画像を投稿|messages||
+|投稿内容表示機能|投稿された内容を表示|messages||
+
+
 ## usersテーブル
 
 |Column|Type|Options|
 |------|----|-------|
-|id|integer||
 |name|string|null: false, add_index|
 |email|string|null: false, unique: true|
 |password|string|null: false|
@@ -12,3 +26,37 @@
 ### Association
 - has_many : user_groups
 - has_many : messages
+
+## groupsテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|group_name|string|null: false|
+
+### Association
+- has_many : user_groups
+- has_many : messages
+
+## user_groupsテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|foreign_key: true|
+|group_id|integer|foreign_key: true|
+
+### Association
+- belongs_to : group
+- belongs_to : user
+
+## messagesテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|body|text|null: false|
+|image|string|
+|group_id|integer|foreign_key: true|
+|user_id|integer|foreign_key: true|
+
+### Association
+- belongs_to : group
+- belongs_to : user

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 
 ### Association
 - has_many : user_groups
+- has_many : groups, through: :user_groups
 - has_many : messages
 
 ## groupsテーブル
@@ -35,6 +36,7 @@
 
 ### Association
 - has_many : user_groups
+- has_many : users, through: :user_groups
 - has_many : messages
 
 ## user_groupsテーブル

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# README
+# DB設計
 
 ## Chatspace 要件定義（未完成）
 |ChatSpace機能|機能詳細|エンティティ|リレーション|

--- a/README.md
+++ b/README.md
@@ -1,24 +1,14 @@
 # README
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+## usersテーブル
 
-Things you may want to cover:
+|Column|Type|Options|
+|------|----|-------|
+|id|integer||
+|name|string|null: false, add_index|
+|email|string|null: false, unique: true|
+|password|string|null: false|
 
-* Ruby version
-
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+### Association
+- has_many : user_groups
+- has_many : messages


### PR DESCRIPTION
# What
データベース設計図をREADMEに記述する。カリキュラム上、必須ではなかったがまずは機能要件を洗い出した上でデータベースを考えた。エンティティとしてはusers,groups,user-groups,messagesの４つを用意した。usersとgroupsが多対多の関係となったため、中間テーブルとしてuser-groupsテーブルを用意した。カラムについて、アソシエーションについての詳細はREADME.mdに記載する。

# Why
ChatSpaceの機能実装に入る前に、まずはどのようなデータを扱う必要があるのか洗い出す必要があるから。設計を行わずに進めてしまうことでの開発の出戻りなどの大きなリスクを防ぐ。
