### PR TITLE
Add Message Function

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,3 +35,6 @@ gem "haml-rails", ">= 1.0", '<= 2.0.1'
 gem 'font-awesome-sass'
 gem 'devise'
 gem 'pry-rails'
+gem 'carrierwave'
+# ImageMagickが必要なので事前にbrew install imagemagickする
+gem 'mini_magick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,13 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
+    carrierwave (2.1.0)
+      activemodel (>= 5.0.0)
+      activesupport (>= 5.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      mimemagic (>= 0.3.0)
+      mini_mime (>= 0.1.3)
     childprocess (3.0.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.6)
@@ -105,6 +112,9 @@ GEM
       ruby_parser (~> 3.5)
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
+    image_processing (1.11.0)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
     listen (3.1.5)
@@ -120,6 +130,7 @@ GEM
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
     mimemagic (0.3.5)
+    mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.1)
@@ -175,6 +186,8 @@ GEM
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    ruby-vips (2.0.17)
+      ffi (~> 1.9)
     ruby_dep (1.5.0)
     ruby_parser (3.14.2)
       sexp_processor (~> 4.9)
@@ -245,11 +258,13 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)
+  carrierwave
   devise
   font-awesome-sass
   haml-rails (>= 1.0, <= 2.0.1)
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
+  mini_magick
   mysql2 (>= 0.4.4)
   pry-rails
   puma (~> 3.11)

--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@
 
 |Column|Type|Options|
 |------|----|-------|
-|body|text|
+|content|string|
 |image|string|
-|group_id|integer|null: false, foreign_key: true|
-|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|foreign_key: true|
+|user_id|integer|foreign_key: true|
 
 ### Association
 - belongs_to : group

--- a/app/assets/stylesheets/modules/_messages.scss
+++ b/app/assets/stylesheets/modules/_messages.scss
@@ -58,18 +58,17 @@
     
     .group-container {
       padding: 20px 0 40px;
+      text-decoration: none;
       
       &__group-name {
         color: #ffffff;
         font-size: 15px;
-        line-height: 15px;
         margin-bottom: 5px;
       }
       
       &__new-message {
         color: #ffffff;
         font-size: 11px;
-        line-height: 11px;
       }
     }
   }
@@ -119,17 +118,18 @@
 
   &__message-list {
     background-color: #fafafa;
-    height: calc(100vh - 100px - 90px);
     padding-left: 40px;
     padding-top: 35px;
-
+    height: calc(100vh - 100px - 90px);
+    overflow: scroll;
+    
     .message-field {
       margin-bottom: 46px;
-
+      
       &__member-box {
-        margin-bottom: 12px;
         display: flex;
-
+        margin-bottom: 12px;
+        
         .member-name {
           color: #333333;
           font-size: 16px;
@@ -141,10 +141,13 @@
           padding-left: 10px;
         }
       }
-
+      
       &__member-message {
         color: #434A54;
         font-size: 14px;
+      }
+      .Message__image {
+        height: 300px;
       }
     }
   }

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -24,7 +24,7 @@ class GroupsController < ApplicationController
   def update
     @group = Group.find(params[:id])
     if @group.update(group_params)
-      redirect_to root_path, notice: 'グループを更新しました'
+      redirect_to group_messages_path(@group.id), notice: 'グループを更新しました'
     else
       render :edit
     end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,4 +1,30 @@
 class MessagesController < ApplicationController
+  before_action :set_group
+
   def index
+    @message = Message.new
+    # 対象グループの各ユーザに紐付いたメッセージを一括取得
+    # @messages = @group.messages.allは省略
+    @messages = @group.messages.includes(:user)
+  end
+
+  def create
+    @message = @group.messages.new(message_params)
+    if @message.save
+      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+    else
+      @messages = @group.messages.includes(:user)
+      flash.now[:alert] = 'メッセージを入力してください。'
+      render :index
+    end
+  end
+
+  private
+  def message_params
+    params.require(:message).permit(:content, :image).merge(user_id: current_user.id)
+  end
+
+  def set_group
+    @group = Group.find(params[:group_id])
   end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -4,4 +4,16 @@ class Group < ApplicationRecord
   has_many :messages
   # バリデーション presence:空でないこと、uniquness:一意
   validates :name, presence: true, uniqueness: true 
+
+  def show_last_message
+    if (last_message = messages.last).present?
+      if last_message.content?
+        last_message.content
+      else
+        '画像が投稿されています'
+      end
+    else
+      'まだメッセージはありません。'
+    end
+  end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,6 +1,7 @@
 class Group < ApplicationRecord
   has_many :user_groups
   has_many :users, through: :user_groups
+  has_many :messages
   # バリデーション presence:空でないこと、uniquness:一意
   validates :name, presence: true, uniqueness: true 
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,8 @@
+class Message < ApplicationRecord
+  belongs_to :group
+  belongs_to :user
+
+  validates :content, presence: true, unless: :image?
+
+  mount_uploader :image, ImageUploader
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,5 +6,6 @@ class User < ApplicationRecord
          
   has_many :user_groups
   has_many :groups, through: :user_groups
+  has_many :messages
   validates :name, presence: true, uniqueness: true
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,0 +1,48 @@
+class ImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+    process resize_to_fit: [800, 800]
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_whitelist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -7,16 +7,7 @@
       %a{"href": "#", "alt": "group-edit-btn"} Edit
 
   .chat-main__message-list
-    .message-field
-      .message-field__member-box
-        .member-name masa
-        .timestamp 2019/11/20(Wed) 17:43:01
-      %p.message-field__member-message おはよう！
-    .message-field
-      .message-field__member-box
-        .member-name masa
-        .timestamp 2019/11/20(Wed) 17:43:43
-      %p.message-field__member-message 今日は夜から雨
+    = render @messages
 
   .chat-main__message-form
     = form_with model: [@group, @message], html: {class: "form"}, local: true do |f|

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -1,10 +1,14 @@
 .chat-main
   .chat-main__group-info
     .group-info
-      .group-info__group-name techcamp
-      .group-info__group-member Member : masa
+      .group-info__group-name
+        = @group.name
+      .group-info__group-member
+        Member : 
+        - @group.users.each do |user|
+          = user.name
     .group-edit-btn
-      %a{"href": "#", "alt": "group-edit-btn"} Edit
+      = link_to 'Edit', edit_group_path(@group.id)
 
   .chat-main__message-list
     = render @messages

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -19,13 +19,13 @@
       %p.message-field__member-message 今日は夜から雨
 
   .chat-main__message-form
-    %form.form{}
+    = form_with model: [@group, @message], html: {class: "form"}, local: true do |f|
       .form__contents
-        %input.inputContent{"type": "text", "placeholder": "type a message"}
-        %label.inputImage{}
+        = f.text_field :content, class: 'inputContent', placeholder: 'type a message'
+        = f.label :image, class: 'inputImage' do
           = icon('far', 'image')
-          %input.Hidden{"type": "file"}
-      %input.form__btn{"type": "submit", "value": "Send"}
+          = f.file_field :image, class: 'Hidden'
+      = f.submit 'Send', class: 'form__btn'
 
     
       

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,0 +1,10 @@
+.message-field
+  .message-field__member-box
+    .member-name
+      = message.user.name
+    .timestamp
+      = message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  - if message.content.present?
+    %p.message-field__member-message
+      = message.content
+  = image_tag message.image.url, class: 'Message__image' if message.image.present?

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -13,8 +13,9 @@
   .side-bar__group-list
     - current_user.groups.each do |group|
       .group-container
-        = link_to '#' do
+        = link_to group_messages_path(group) do
           .group-container__group-name
             = group.name
-          %p.group-container__new-message
-            まだメッセージがありません
+          .group-container__new-message
+            = group.show_last_message
+           

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,5 +16,9 @@ module ChatSpace
       g.test_framework false
     end
     config.i18n.default_locale = :ja
+    
+    # railsがエラーの時に勝手に作るdiv要素を排除
+    config.action_view.field_error_proc = Proc.new { |html_tag, instance| html_tag }
   end
 end
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,7 @@ Rails.application.routes.draw do
 
   root "groups#index"
   resources :users, only: [:edit, :update]
-  resources :groups, only: [:index, :new, :create, :edit, :update]
+  resources :groups, only: [:index, :new, :create, :edit, :update] do
+    resources :messages, only: [:index, :create]
+  end
 end

--- a/db/migrate/20200708064030_create_messages.rb
+++ b/db/migrate/20200708064030_create_messages.rb
@@ -1,0 +1,11 @@
+class CreateMessages < ActiveRecord::Migration[6.0]
+  def change
+    create_table :messages do |t|
+      t.string :content
+      t.string :image
+      t.references :group,  foreign_key: true
+      t.references :user,   foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_08_021421) do
+ActiveRecord::Schema.define(version: 2020_07_08_064030) do
 
   create_table "groups", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["name"], name: "index_groups_on_name", unique: true
+  end
+
+  create_table "messages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "content"
+    t.string "image"
+    t.bigint "group_id"
+    t.bigint "user_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["group_id"], name: "index_messages_on_group_id"
+    t.index ["user_id"], name: "index_messages_on_user_id"
   end
 
   create_table "user_groups", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -42,4 +53,6 @@ ActiveRecord::Schema.define(version: 2020_07_08_021421) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "messages", "groups"
+  add_foreign_key "messages", "users"
 end


### PR DESCRIPTION
# メッセージ送信機能の実装
## メッセージ送信機能の実装
- messageモデルの作成
- メッセージ送信画面とメッセージの保存が必要なため、index及びcreateアクションのルーティング記述
- 画像のリサイズ送信のためCarrierWaveのとminimagickのGemインストール
- メッセージ送信機能の実装
- index、createアクションの処理を記述
- railsのバリデーションエラーで、「field_with_errors」
によるレイアウト崩れの対応
- フラッシュメッセージの記述
### 修正箇所
- カラム名をbodyからcontentに変更。型もtextからstringへ変更。READMEを修正

## グループチャットにメッセージを表示する

## サイドバーに最新のメッセージを表示

## ヘッダー表示の実装
- 現在表示しているグループ名が表示されるように変更
- 現在のグループに所属しているメンバーが表示されるように変更

## グループ編集ページへのリンク設置

## グループ編集後のリダイレクト先を今いるグループのメッセージ一覧が表示されるように変更