### PR TITLE
Update Ajax Message Posting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,3 +42,4 @@ gem 'font-awesome-sass'
 gem 'carrierwave'
 # ImageMagickが必要なので事前にbrew install imagemagickする
 gem 'mini_magick'
+gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,10 @@ GEM
       ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
+    jquery-rails (4.4.0)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -294,6 +298,7 @@ DEPENDENCIES
   font-awesome-sass
   haml-rails (>= 1.0, <= 2.0.1)
   jbuilder (~> 2.7)
+  jquery-rails
   listen (>= 3.0.5, < 3.2)
   mini_magick
   mysql2 (>= 0.4.4)

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_tree ../images
+//= link_directory ../javascripts .js
 //= link_directory ../stylesheets .css

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,0 +1,3 @@
+//= require jquery
+//= require rails-ujs
+//= require_tree .

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -30,7 +30,6 @@ $(function(){
 
   $('.form').on('submit', function(e) {
     e.preventDefault();
-    console.log(this);
     let formData = new FormData(this);
     let url = $(this).attr('action');
     

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,55 @@
+$(function(){
+  function buildHTML(message) {
+    if (message.image) {
+      // messageに画像が含まれていた場合の処理
+      let html = `
+      <div class="message-field">
+        <div class="message-field__member-box">
+          <div class="member-name">${message.user_name}</div>
+          <div class="timestamp">${message.created_at}</div>
+        </div>
+        <p class="message-field__member-message">${message.content}</p>
+        <img class="Message__image" src="${message.image}">
+      </div>
+      `
+      return html
+    } else {
+      // messageに画像が含まれていない場合の処理
+      let html = `
+      <div class="message-field">
+        <div class="message-field__member-box">
+          <div class="member-name">${message.user_name}</div>
+          <div class="timestamp">${message.created_at}</div>
+        </div>
+        <p class="message-field__member-message">${message.content}</p>
+      </div>
+      `
+      return html
+    }
+  }
+
+  $('.form').on('submit', function(e) {
+    e.preventDefault();
+    console.log(this);
+    let formData = new FormData(this);
+    let url = $(this).attr('action');
+    
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+    .done(function(data){
+      let html = buildHTML(data);
+      $('.chat-main__message-list').append(html).animate({ scrollTop: $('.chat-main__message-list')[0].scrollHeight});;
+      $('form')[0].reset();
+      $('.form__btn').prop('disabled',false);
+    })
+    .fail(function() {
+      alert("メッセージ送信に失敗しました")
+    });
+  });
+});

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -11,7 +11,10 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        # format.html { redirect_to group_messages_path(@group), notice: 'メッセージが送信されました' }
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,7 +6,8 @@
     = csrf_meta_tags
     = csp_meta_tag
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
+    = javascript_include_tag 'application'
+    -# = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
   %body
     = render 'layouts/notifications'
     = yield

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.user_name @message.user.name
+json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+json.content @message.content
+json.image @message.image_url

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,7 @@ module ChatSpace
       g.test_framework false
     end
     config.i18n.default_locale = :ja
+    config.time_zone = 'Tokyo'
     
     # railsがエラーの時に勝手に作るdiv要素を排除
     config.action_view.field_error_proc = Proc.new { |html_tag, instance| html_tag }


### PR DESCRIPTION
# Why
## メッセージ投稿機能の非同期通信を実装
 - 画面リロード不要
 - テキストのみ、画像のみ、画像とテキスト、それぞれで非同期通信にてメッセージ投稿可能
- 連続投稿可能
- 投稿と同時に最下部へスクロールする機能
- 日時表記を日本時間に修正
- 空メッセージ送信によるエラーのアラート機能

# What
- チャットということでレスポンスの頻度が多いと想定されるため、画面をリロードすることなくメッセージが表示できることにより操作性の向上を実現する

# Move
動画は以下です。
## メッセージのみ
https://gyazo.com/022c5c68b865e6ce4db37385774e626e

## 画像のみ
https://gyazo.com/33e83bf1474be00e15950cdccedbd2e5

## 画像とテキスト
https://gyazo.com/e7fa01698beddda3ed066168b30c473f

## エラー
https://gyazo.com/cea22626eaf4094141504b1334ef51f5